### PR TITLE
Define Torch-related types in the stub file, not as built-in

### DIFF
--- a/src/Staged/Typechecker.hs
+++ b/src/Staged/Typechecker.hs
@@ -1317,17 +1317,19 @@ typecheckTypeExpr0 trav tyEnv (Expr loc tyeMain) = do
           a0e <- forceExpr0 trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg
           ns <- validateIntListLiteral trav loc' a0e
           pure $ A0TyPrim (A0TyTensor ns) Nothing
-        ([], "Dataset", [arg1@(Expr loc1 _), arg2@(Expr loc2 _), arg3@(Expr loc3 _), arg4@(Expr loc4 _)]) -> do
-          a0e1 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg1
-          a0e2 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg2
-          a0e3 <- forceExpr0 trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg3
-          a0e4 <- forceExpr0 trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg4
-          numTrain <- validateIntLiteral trav loc1 a0e1
-          numTest <- validateIntLiteral trav loc2 a0e2
-          image <- validateIntListLiteral trav loc3 a0e3
-          label <- validateIntListLiteral trav loc4 a0e4
-          let datasetParam = DatasetParam {numTrain, numTest, image, label}
-          pure $ A0TyPrim (A0TyDataset datasetParam) Nothing
+        {-
+          ([], "Dataset", [arg1@(Expr loc1 _), arg2@(Expr loc2 _), arg3@(Expr loc3 _), arg4@(Expr loc4 _)]) -> do
+            a0e1 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg1
+            a0e2 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg2
+            a0e3 <- forceExpr0 trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg3
+            a0e4 <- forceExpr0 trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg4
+            numTrain <- validateIntLiteral trav loc1 a0e1
+            numTest <- validateIntLiteral trav loc2 a0e2
+            image <- validateIntListLiteral trav loc3 a0e3
+            label <- validateIntListLiteral trav loc4 a0e4
+            let datasetParam = DatasetParam {numTrain, numTest, image, label}
+            pure $ A0TyPrim (A0TyDataset datasetParam) Nothing
+        -}
         ([], "Lstm", [arg1@(Expr loc1 _), arg2@(Expr loc2 _)]) -> do
           a0e1 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg1
           a0e2 <- forceExpr0 trav tyEnv BuiltIn.tyNat arg2
@@ -1553,20 +1555,22 @@ typecheckTypeExpr1 trav tyEnv (Expr loc tyeMain) = do
                   logShapeAnnot (ShapeAnnotLog loc)
                   a0eList <- validatePersistentExprArg trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg
                   pure $ A1TyPrim (A1TyTensor a0eList)
-                ("Dataset", [arg1, arg2, arg3, arg4]) -> do
-                  logShapeAnnot (ShapeAnnotLog loc)
-                  a0e1 <- validatePersistentExprArg trav tyEnv BuiltIn.tyNat arg1
-                  a0e2 <- validatePersistentExprArg trav tyEnv BuiltIn.tyNat arg2
-                  a0e3 <- validatePersistentExprArg trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg3
-                  a0e4 <- validatePersistentExprArg trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg4
-                  let datasetParam =
-                        DatasetParam
-                          { numTrain = a0e1,
-                            numTest = a0e2,
-                            image = Identity a0e3,
-                            label = Identity a0e4
-                          }
-                  pure $ A1TyPrim (A1TyDataset datasetParam)
+                {-
+                  ("Dataset", [arg1, arg2, arg3, arg4]) -> do
+                    logShapeAnnot (ShapeAnnotLog loc)
+                    a0e1 <- validatePersistentExprArg trav tyEnv BuiltIn.tyNat arg1
+                    a0e2 <- validatePersistentExprArg trav tyEnv BuiltIn.tyNat arg2
+                    a0e3 <- validatePersistentExprArg trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg3
+                    a0e4 <- validatePersistentExprArg trav tyEnv (A0TyList BuiltIn.tyNat Nothing) arg4
+                    let datasetParam =
+                          DatasetParam
+                            { numTrain = a0e1,
+                              numTest = a0e2,
+                              image = Identity a0e3,
+                              label = Identity a0e4
+                            }
+                    pure $ A1TyPrim (A1TyDataset datasetParam)
+                -}
                 ("Lstm", [arg1, arg2]) -> do
                   logShapeAnnot (ShapeAnnotLog loc)
                   a0eInputSize <- validatePersistentExprArg trav tyEnv BuiltIn.tyNat arg1

--- a/stub.lbam
+++ b/stub.lbam
@@ -660,6 +660,13 @@ module Checkpointing = struct
     external (builtin = "checkpointing__loop", surface = "loop")
 end
 
+type Dataset %(ntrain : Nat) %(ntest : Nat) %(image : List Nat) %(label : List Nat) = (|
+  train_images : Tensor %(ntrain :: image),
+  train_labels : Tensor %(ntrain :: label),
+  test_images  : Tensor %(ntest :: image),
+  test_labels  : Tensor %(ntest :: label)
+|)
+
 module DatasetHelper = struct
   val ~gen_train_batch :
     {ntrain : Nat} ->


### PR DESCRIPTION
This should be done after supporting datatypes (in order not to harm implicit argument inference):

```
data Dataset %(ntrain : Nat) %(ntest : Nat) %(image : List Nat) %(label : List Nat) =
  | Dataset (|
      train_images : Tensor %(ntrain :: image),
      train_labels : Tensor %(ntrain :: label),
      test_images  : Tensor %(ntest :: image),
      test_labels  : Tensor %(ntest :: label)
    |)
```